### PR TITLE
mmol display fixes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -105,12 +105,16 @@ async function getSettings(nightscoutUrl: string, token: string): Promise<Settin
   console.log(`Fetching settings...`)
   const response = await fetch(`${nightscoutUrl}/api/v1/status.json?token=${token}`)
   const status = await response.json()
-  const multiplier = status.settings.units === "mmol" ? MMOL_TO_MGDL : 1
+  const targetRangeUnit = status.settings.thresholds.bgTargetTop > 30 ? "mgdl" : "mmol"
+  const multiplier = status.settings.units === "mmol" && targetRangeUnit == "mmol" ? MMOL_TO_MGDL : 1
   return {
     nightscoutTitle: status.settings.customTitle,
     nightscoutUrl,
     displayUnits: status.settings.units,
-    targetRangeMgdl: [status.settings.thresholds.bgTargetBottom, status.settings.thresholds.bgTargetTop]
+    targetRangeMgdl: [status.settings.thresholds.bgTargetBottom, status.settings.thresholds.bgTargetTop].map(
+      (x: number) => x * multiplier
+    ) as [number, number],
+    targetRangeUnit,
   }
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -110,9 +110,7 @@ async function getSettings(nightscoutUrl: string, token: string): Promise<Settin
     nightscoutTitle: status.settings.customTitle,
     nightscoutUrl,
     displayUnits: status.settings.units,
-    targetRangeMgdl: [status.settings.thresholds.bgTargetBottom, status.settings.thresholds.bgTargetTop].map(
-      (x: number) => x * multiplier
-    ) as [number, number],
+    targetRangeMgdl: [status.settings.thresholds.bgTargetBottom, status.settings.thresholds.bgTargetTop]
   }
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -106,7 +106,7 @@ async function getSettings(nightscoutUrl: string, token: string): Promise<Settin
   const response = await fetch(`${nightscoutUrl}/api/v1/status.json?token=${token}`)
   const status = await response.json()
   const targetRangeUnit = status.settings.thresholds.bgTargetTop > 30 ? "mgdl" : "mmol"
-  const multiplier = status.settings.units === "mmol" && targetRangeUnit == "mmol" ? MMOL_TO_MGDL : 1
+  const multiplier = status.settings.units === "mmol" && targetRangeUnit === "mmol" ? MMOL_TO_MGDL : 1
   return {
     nightscoutTitle: status.settings.customTitle,
     nightscoutUrl,

--- a/src/data.ts
+++ b/src/data.ts
@@ -9,6 +9,7 @@ export interface Settings {
   nightscoutUrl: string
   displayUnits: "mgdl" | "mmol"
   targetRangeMgdl: [number, number]
+  targetRangeUnit: "mgdl" | "mmol"
 }
 
 export interface GlucoseRecord {

--- a/src/heatmap.ts
+++ b/src/heatmap.ts
@@ -23,8 +23,10 @@ export function renderHeatmap(settings: Settings, glucoseData: GlucoseRecord[]):
 
 function renderHeader(settings: Settings): string {
   let targetRange = settings.targetRangeMgdl
+  let bgDisplay = `${targetRange[0]}&mdash;${targetRange[1]}`
   if (settings.displayUnits === "mmol") {
     targetRange = targetRange.map((x) => x / MMOL_TO_MGDL) as [number, number]
+    bgDisplay = `${targetRange[0].toFixed(1)}&mdash;${targetRange[1].toFixed(1)}`
   }
   const units = settings.displayUnits === "mmol" ? "mmol/l" : "mg/dl"
   return `
@@ -34,7 +36,7 @@ function renderHeader(settings: Settings): string {
       ∝
       <a target="_blank" href="https://github.com/vitawasalreadytaken/glucoscape">Glucoscape</a>
       <span class="target">
-        // target ${targetRange[0]}&mdash;${targetRange[1]} ${units}
+        // target ${bgDisplay} ${units}
       </span>
     </header>
   `

--- a/src/heatmap.ts
+++ b/src/heatmap.ts
@@ -24,7 +24,7 @@ export function renderHeatmap(settings: Settings, glucoseData: GlucoseRecord[]):
 function renderHeader(settings: Settings): string {
   let targetRange = settings.targetRangeMgdl
   let bgDisplay = `${targetRange[0]}&mdash;${targetRange[1]}`
-  if (settings.displayUnits === "mmol") {
+  if (settings.displayUnits === "mmol" && settings.targetRangeUnit == "mgdl") {
     targetRange = targetRange.map((x) => x / MMOL_TO_MGDL) as [number, number]
     bgDisplay = `${targetRange[0].toFixed(1)}&mdash;${targetRange[1].toFixed(1)}`
   }


### PR DESCRIPTION
Some fixes for mmol/l display

* Nightscout's API returns mg/dl for target range, even if nightscout's display is set to mmol so this doesn't need multiplying in app.ts (this was causing all reading to be out of range)
![image](https://github.com/vitawasalreadytaken/glucoscape/assets/47819665/87e70e1a-c79d-40fb-902a-b8f9421e737d)

* {targetRange} when converted to mmol should be fixed to 1 decimal place, otherwise it displays large amounts of digits due to floating point division (i.e. a target high of 180 mg/dl reads 9.99000000000999)
![image](https://github.com/vitawasalreadytaken/glucoscape/assets/47819665/41b0d874-a8ed-4bfa-8550-320cb4d1c2ae)


Both of these can be tested with my nightscout instance. Running on 
nightscout.ransomti.me with token [reporter-eedc563cda3d55b7](https://nightscout.ransomti.me/?token=reporter-eedc563cda3d55b7)